### PR TITLE
Reset some Staticman config to upstream

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -135,7 +135,7 @@ staticman:
     # reCaptcha for Staticman (OPTIONAL, but recommended for spam protection)
     # If you use reCaptcha, you must also set these parameters in staticman.yml
     siteKey  : # Use your own site key, you need to apply for one on Google
-secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
+    secret   : # ENCRYPT your password by going to https://staticman3.herokuapp.com/v3/encrypt/<your-site-secret>
 
 # --- Misc --- #
 

--- a/staticman.yml
+++ b/staticman.yml
@@ -1,0 +1,110 @@
+# Name of the property. You can have multiple properties with completely
+# different config blocks for different sections of your site.
+# For example, you can have one property to handle comment submission and
+# another one to handle posts.
+# To encrypt strings use the following endpoint:
+# https://{STATICMAN API INSTANCE}/v3/encrypt/{TEXT TO BE ENCRYPTED}
+# {STATICMAN API INSTANCE} should match the `endpoint` in the theme config
+# file. It defaults to "staticman3.herokuapp.com".
+
+comments:
+  # (*) REQUIRED
+  #
+  # Names of the fields the form is allowed to submit. If a field that is
+  # not here is part of the request, an error will be thrown.
+  allowedFields: ["name", "email", "url", "message"]
+
+  # (*) REQUIRED WHEN USING NOTIFICATIONS
+  #
+  # When allowedOrigins is defined, only requests sent from one of the domains
+  # listed will be accepted. The origin is sent as part as the `options` object
+  # (e.g. <input name="options[origin]" value="http://yourdomain.com/post1")
+  # allowedOrigins: ["https://example.com"]
+
+  # (*) REQUIRED
+  #
+  # Name of the branch being used. Must match the `branch` in the theme config
+  # file.
+  branch: "master"   #  use "master" for user page or "gh-pages" for project pages
+
+  commitMessage: "New comment by {fields.name}"
+
+  # (*) REQUIRED
+  #
+  # Destination path (filename) for the data files. Accepts placeholders.
+  filename: "comment-{@timestamp}"
+
+  # The format of the generated data files. Accepted values are "json", "yaml"
+  # or "frontmatter"
+  format: "yaml"
+
+  # List of fields to be populated automatically by Staticman and included in
+  # the data file. Keys are the name of the field. The value can be an object
+  # with a `type` property, which configures the generated field, or any value
+  # to be used directly (e.g. a string, number or array)
+  generatedFields:
+    date:
+      type: "date"
+      options:
+        format: "iso8601" # "iso8601" (default), "timestamp-seconds", "timestamp-milliseconds"
+
+  # Whether entries need to be approved before they are published to the main
+  # branch. If set to `true`, a pull request will be created for your approval.
+  # Otherwise, entries will be published to the main branch automatically.
+  moderation: false
+
+  # Akismet spam detection.
+  # akismet:
+  #   enabled: true
+  #   author: "name"
+  #   authorEmail: "email"
+  #   authorUrl: "url"
+  #   content: "message"
+  #   type: "comment"
+
+  # Name of the site. Used in notification emails.
+  # name: "Your Site"
+
+  # Notification settings. When enabled, users can choose to receive notifications
+  # via email when someone adds a reply or a new comment. This requires an account
+  # with Mailgun, which you can get for free at http://mailgun.com.
+  # notifications:
+    # Enable notifications
+    # enabled: true
+
+    # (!) ENCRYPTED
+    #
+    # Mailgun API key
+    # apiKey: ""
+
+    # (!) ENCRYPTED
+    #
+    # Mailgun domain (encrypted)
+    # domain: ""
+
+  # (*) REQUIRED
+  #
+  # Destination path (directory) for the data files. Accepts placeholders.
+  path: "_data/comments/{options.slug}" # (default)
+
+  # Names of required files. If any of these isn't in the request or is empty,
+  # an error will be thrown.
+  requiredFields: ["name", "email", "message"]
+
+  # List of transformations to apply to any of the fields supplied. Keys are
+  # the name of the field and values are possible transformation types.
+  transforms:
+    email: md5
+
+  # reCAPTCHA (OPTIONAL)
+  # To enable reCAPTCHA:
+  # 1. Set `enabled` to `true`
+  # 2. Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
+  # 3. Uncomment `siteKey` and `secret` and fill them in with your values
+  reCaptcha:
+    enabled: false
+    #siteKey: ""
+    # ENCRYPT reCaptcha secret key using Staticman /encrypt endpoint
+    # i.e. https://{STATICMAN API INSTANCE}/v3/encrypt/{your-site-secret}
+    # For more information, visit https://staticman.net/docs/encryption
+    #secret: ""


### PR DESCRIPTION
In daattali/beautiful-jekyll@94161dbef, the indentation of `siteKey` and `secret` are the same.  The root-level `staticman.yml` is necessary for Staticman to function, according to [Staticman's docs](https://staticman.net/docs/#step-2-create-a-configuration-file).  The fille name and path have to be exact.